### PR TITLE
feat: assert demo workgroup

### DIFF
--- a/igrafx_mining_sdk/workgroup.py
+++ b/igrafx_mining_sdk/workgroup.py
@@ -53,7 +53,7 @@ class Workgroup:
     @property
     def get_workgroup_metadata(self):
         """
-        Returns the metadata of the workgroup
+        Returns the metadata of the workgroup such as creation date, name, start validity date, isDemoWorkgroup
         """
         response_workgroup_metadata = self.api_connector.get_request(f"/workgroups/{self.w_id}")
         return response_workgroup_metadata.json()

--- a/tests/test_00_workgroup.py
+++ b/tests/test_00_workgroup.py
@@ -45,7 +45,8 @@ class TestWorkgroup:
     @pytest.mark.dependency(depends=['workgroup'])
     def test_projects(self):
         """Test that there are projects in the workgroup."""
-        assert len(pytest.workgroup.get_project_list()) > 0  # There should be at least one project in the workgroup
+        # There should be at least one project in the workgroup
+        assert len(pytest.workgroup.get_project_list()) > 0
 
     @pytest.mark.dependency(depends=['workgroup'])
     def test_project_from_id(self):
@@ -58,6 +59,8 @@ class TestWorkgroup:
         assert pytest.workgroup.get_workgroup_metadata
         assert pytest.workgroup.get_workgroup_metadata.get("name")
         assert pytest.workgroup.get_workgroup_metadata.get("creationDate")
+        assert pytest.workgroup.get_workgroup_metadata.get("startValidityDate")
+        assert pytest.workgroup.get_workgroup_metadata.get("isDemoWorkgroup")
 
     @pytest.mark.dependency(depends=['workgroup'])
     def test_get_workgroup_data_version(self):


### PR DESCRIPTION
Modify the necessary tests and descriptions to check if isDemoWorkgroup attribute is retrieved. Note that as of now the test will not pass as it is not yet on staging.