### PR TITLE
feat/PROC-5feat/PROC-5773-support-large-file-ingestion

### DIFF
--- a/howto.md
+++ b/howto.md
@@ -417,6 +417,9 @@ Note that a **zip** file can also be sent. To do so, in the file structure,
 the declared file type should be the final format of the file within the zip (e.g., .csv, .xlsx, .xls).
 And when giving the file path in the ``add_file`` method, give the zip name.
 
+Furthermore, a large file (>1GB) can also be sent by using the ``add_file`` method.
+If you send a file with an unsupported format, the file will not be processed and you will get an error.
+
 Additionally, the status of the added file(s) can be checked by using the following method:
 
 ````python

--- a/igrafx_mining_sdk/api_connector.py
+++ b/igrafx_mining_sdk/api_connector.py
@@ -105,7 +105,6 @@ class APIConnector:
             print(response.text)
         return response
 
-
     def post_request(self,
                      route,
                      *,

--- a/igrafx_mining_sdk/api_connector.py
+++ b/igrafx_mining_sdk/api_connector.py
@@ -105,7 +105,17 @@ class APIConnector:
             print(response.text)
         return response
 
-    def post_request(self, route, *, params=None, json=None, files=None, data=None, headers={}, nblasttries=0, maxtries=3):
+
+    def post_request(self,
+                     route,
+                     *,
+                     params=None,
+                     json=None,
+                     files=None,
+                     data=None,
+                     headers={},
+                     nblasttries=0,
+                     maxtries=3):
         """Does an HTTP POST request to the Mining Public API by simply taking the route, an eventual JSON,
         files and headers
 

--- a/igrafx_mining_sdk/api_connector.py
+++ b/igrafx_mining_sdk/api_connector.py
@@ -122,7 +122,7 @@ class APIConnector:
         :param params: The parameters of the request
         :param json: A given JSON object
         :param files: Eventual files
-        :param data: Raw binary data for application/octet-stream requests
+        :param data: Raw binary data for application/octet-stream requests, if needed
         :param headers: Additional headers
         :param nblasttries: The number of try of this route
         :param maxtries: The maximum number of tries

--- a/igrafx_mining_sdk/api_connector.py
+++ b/igrafx_mining_sdk/api_connector.py
@@ -105,7 +105,7 @@ class APIConnector:
             print(response.text)
         return response
 
-    def post_request(self, route, *, params=None, json=None, files=None, headers={}, nblasttries=0, maxtries=3):
+    def post_request(self, route, *, params=None, json=None, files=None, data=None, headers={}, nblasttries=0, maxtries=3):
         """Does an HTTP POST request to the Mining Public API by simply taking the route, an eventual JSON,
         files and headers
 
@@ -113,6 +113,7 @@ class APIConnector:
         :param params: The parameters of the request
         :param json: A given JSON object
         :param files: Eventual files
+        :param data: Raw binary data for application/octet-stream requests
         :param headers: Additional headers
         :param nblasttries: The number of try of this route
         :param maxtries: The maximum number of tries
@@ -125,6 +126,7 @@ class APIConnector:
                                 params=params,
                                 json=json,
                                 files=files,
+                                data=data,
                                 headers={**self.token_header, **headers},
                                 verify=self.ssl_verify)
             if response.status_code == 401:  # Only possible if the token has expired
@@ -133,6 +135,7 @@ class APIConnector:
                     self.post_request(route,
                                       json=json,
                                       files=files,
+                                      data=data,
                                       headers=headers,
                                       nblasttries=nblasttries + 1,
                                       maxtries=maxtries)

--- a/igrafx_mining_sdk/project.py
+++ b/igrafx_mining_sdk/project.py
@@ -265,25 +265,21 @@ class Project:
 
         :param path: The path to the file to add
         """
-        route = f"/project/{self.id}/file?teamId={self.api_connector.wg_id}"
         file_extension = os.path.splitext(path)[-1].lower()
-        if file_extension == ".csv":
-            mime_type = "text/csv"
-        elif file_extension == ".xlsx":
-            mime_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-        elif file_extension == ".xls":
-            mime_type = "application/vnd.ms-excel"
-        elif file_extension == ".zip":
-            # When a zip is added, the mime type is a zip file.
-            # The file type is automatically detected through the file structure
-            mime_type = "application/zip"
-        else:
+        if file_extension not in (".csv", ".xlsx", ".xls", ".zip"):
             raise ValueError(f"File extension {file_extension} is not supported")
 
+        route = f"/workgroups/{self.api_connector.wg_id}/projects/{self.id}/files"
+
+        filename = os.path.basename(path)
+        headers = {
+            "accept": "application/json, text/plain, */*",
+            "Content-Type": "application/octet-stream",
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        }
+
         with open(path, 'rb') as file:
-            files = {'file': (os.path.basename(path), file, mime_type)}
-            headers = {"accept": "application/json, text/plain, */*"}
-            response_add_file = self.api_connector.post_request(route, files=files, headers=headers)
+            response_add_file = self.api_connector.post_request(route, data=file, headers=headers)
 
         # print(response_add_file.status_code) to get the status response
         if response_add_file.status_code == 201:

--- a/tests/test_02_project.py
+++ b/tests/test_02_project.py
@@ -1,5 +1,6 @@
 # MIT License, Copyright 2023 iGrafx
 # https://github.com/igrafx/mining-python-sdk/blob/dev/LICENSE
+import tempfile
 import time
 from unittest.mock import MagicMock
 from pathlib import Path
@@ -69,18 +70,19 @@ class TestProject:
         """Test that a project can be reset."""
         assert pytest.project.reset()
 
+    @pytest.mark.dependency(depends=['project'], scope='session')
     def test_add_wrong_extension_file(self):
         """Test that adding a file with wrong extension raises ValueError"""
-        base_dir = Path(__file__).resolve().parent
-        # Create a temporary file with unsupported extension
-        temp_file = base_dir / 'data' / 'tables' / 'temp_file.txt'
-        temp_file.write_text("test content")
 
-        with pytest.raises(ValueError, match="File extension .txt is not supported"):
-            pytest.project.add_file(str(temp_file))
+        with tempfile.NamedTemporaryFile(suffix='.txt', delete=False) as temp_file:
+            temp_file.write(b"test content")  # Use write() with bytes for tempfile
+            temp_file_path = temp_file.name
 
-        # Clean up the temporary file
-        temp_file.unlink()
+        try:
+            with pytest.raises(ValueError, match="File extension .txt is not supported"):
+                pytest.project.add_file(temp_file_path)
+        finally:
+            Path(temp_file_path).unlink(missing_ok=True)
 
     @pytest.mark.dependency(depends=['reset', 'add_column_mapping'])
     def test_add_xlsx_file(self):

--- a/tests/test_02_project.py
+++ b/tests/test_02_project.py
@@ -69,6 +69,20 @@ class TestProject:
         """Test that a project can be reset."""
         assert pytest.project.reset()
 
+
+    def test_add_wrong_extension_file(self):
+        """Test that adding a file with wrong extension raises ValueError"""
+        base_dir = Path(__file__).resolve().parent
+        # Create a temporary file with unsupported extension
+        temp_file = base_dir / 'data' / 'tables' / 'temp_file.txt'
+        temp_file.write_text("test content")
+
+        with pytest.raises(ValueError, match="File extension .txt is not supported"):
+            pytest.project.add_file(str(temp_file))
+
+        # Clean up the temporary file
+        temp_file.unlink()
+
     @pytest.mark.dependency(depends=['reset', 'add_column_mapping'])
     def test_add_xlsx_file(self):
         """Test that a xlsx file can be added to a project."""

--- a/tests/test_02_project.py
+++ b/tests/test_02_project.py
@@ -69,7 +69,6 @@ class TestProject:
         """Test that a project can be reset."""
         assert pytest.project.reset()
 
-
     def test_add_wrong_extension_file(self):
         """Test that adding a file with wrong extension raises ValueError"""
         base_dir = Path(__file__).resolve().parent


### PR DESCRIPTION
### 🔍 Objective (Required)
_What is the goal of this MR? Why is it being changed? What are the impacted features?_

Update route to send files. Now the route can send larger files (>1GB)


---

### 🧩 Implementation Summary (Required)
_Describe **how** the objective was achieved. Focus on functional and architectural aspects, not file names_

- Added extension check
- Change headers to accept octet stream
- Modify post method to be able to send octet data
- Added wrong extension test
- Updated doc accordingly

---

### 📁 Affected Modules (Optional)
_List any major classes, functions, or files touched._

- project.py
- api_connector.py
- test_02_project.py
- howto.md

---

### 🧪 How to Test & How It Was Tested (Required)
_Describe how this MR was verified to work correctly. Include both automated and manual tests where applicable._

Testing is **mandatory** for all MRs.  
If only automated tests apply, mark the relevant checkboxes and describe results.  
If manual verification was performed (e.g., API endpoint tests), describe the steps and expected results.

#### ✅ Automated Tests
- [x] New tests were added for new functionality
- [x] Existing tests were updated.
- [x] All existing tests pass locally (`pytest`)
- [x] All tests pass in CI/CD pipeline
- [x] Coverage maintained or improved


#### 🏁 Expected Outputs
- [x] All tests pass

---

### 🔗 Related Issues / MRs
- Related to #5773
